### PR TITLE
Enable Auto-Updater via GitHub Releases (Windows NSIS)

### DIFF
--- a/.github/workflows/app_release.yml
+++ b/.github/workflows/app_release.yml
@@ -1,0 +1,23 @@
+name: Release Windows
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+env:
+  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}  
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: 
+          node-version: "20"
+          cache: "npm"
+      - run: npm ci
+      - run: npm run build
+      - run: npx electron-builder -w --publish always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.0.0] - 2025-08-28
+## [2.0.1] - 2025-08-29
+
+### Added
+
+- Auto-update flow via `electron-builder` + `electron-updater` (GitHub provider).
+- Update dialogs and progress logging: `update-available`, `update-not-available`, `download-progress`, `update-downloaded`, `error`.
+- CI: GitHub Actions workflow to build & publish Windows NSIS releases on tag push (`.github/workflows/app_release.yml`).
+
 ### Changed
+
+- Call `autoUpdater.checkForUpdatesAndNotify()` after `app.whenReady()` only in packaged builds.
+- UX: prompt user to **Restart** or **Later** after download.
+
+### Removed
+
+- `autoUpdater.setFeedURL(...)` (not needed with GitHub provider).
+
+### Contributors
+
+- @CortoMaltese3
+
+## [2.0.0] - 2025-08-28
+
+### Changed
+
 - **Frontend migration** from Create React App (CRA) to Vite for faster builds, leaner configuration, and modern standards.
 - **Electron configuration** updated:
   - Enabled `contextIsolation` and `sandbox` while disabling `nodeIntegration` for improved security.
@@ -22,17 +45,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Updated meta information and security-related headers to address Electron console warnings.
 
 ### Added
+
 - `npm run dev` script for Vite development server with hot module reloading.
 - `npm run quickstart` for launching Electron without rebuilding when already built.
 
 ### Removed
+
 - Deprecated CRA dependencies and configurations.
 - Legacy Emotion deduplication and unnecessary overrides in package.json.
 
 ### Fixed
+
 - File extension inconsistencies (`.js` → `.jsx`) to align with Vite import rules.
 - Dependency mismatches after migration (restored stable versions for React, Emotion, and Vite ecosystem).
 - Security warnings in Electron DevTools by adjusting preload and CSP settings.
 
 ### Contributors
+
 - @CortoMaltese3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "riskwise",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "riskwise",
-      "version": "1.0.0",
+      "version": "2.0.0",
       "dependencies": {
         "@emotion/react": "11.11.4",
         "@emotion/styled": "11.11.5",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "productName": "RISK WISE v2",
   "description": "Desktop GUI application for fully probabilistic climate risk assessment tool Climada. Provides a framework for users to combine exposure, hazard and vulnerability or impact data to calculate risk.",
   "author": "Sword Group <georgios.kalomalos@sword-group.com>",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "main": "build/electron.js",
   "homepage": ".",
@@ -14,7 +14,8 @@
     "start:electron": "npm run build && electron .",
     "quickstart": "electron .",
     "pack": "electron-builder --dir",
-    "dist": "electron-builder -w"
+    "dist": "electron-builder -w",
+    "publish": "electron-builder -w --publish always"
   },
   "dependencies": {
     "@emotion/react": "11.11.4",
@@ -78,9 +79,10 @@
     "artifactName": "RiskWiseInstaller-v${version}-Setup.${ext}",
     "publish": [
       {
-        "provider": "generic",
-        "url": "https://ath-git.swordgroup.lan/unu/climada-unu/-/releases",
-        "channel": "latest"
+        "provider": "github",
+        "owner": "CortoMaltese3",
+        "repo": "RISK_WISE_v2",
+        "releaseType": "release"
       }
     ],
     "generateUpdatesFilesForAllChannels": true,


### PR DESCRIPTION
**Summary**
Adds in-app auto-update support using `electron-builder` + `electron-updater` with the GitHub provider. Users get background download and a restart prompt on new releases.

**Changes**
- Configure `build.publish` to GitHub in `package.json`.
- Call `autoUpdater.checkForUpdatesAndNotify()` after `app.whenReady()` (packaged only).
- Add listeners for `update-available`, `download-progress`, `update-downloaded`, `error`.
- Add CI workflow: `.github/workflows/app_release.yml` to build & publish on tag push.

**Testing**
- Install v2.0.0, tag and publish v2.0.1, launch app → observe background download and restart prompt.